### PR TITLE
seeded scientific name of none in schema

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -49,9 +49,11 @@ CREATE TABLE delta.Locations (
 );
 
 CREATE TABLE delta.Scientific_Names (
-    scientific_id INT IDENTITY (1, 1) PRIMARY KEY,
+    scientific_id INT IDENTITY (0, 1) PRIMARY KEY,
     scientific_name VARCHAR(50) NOT NULL UNIQUE
 );
+
+INSERT INTO delta.Scientific_Names (scientific_name) VALUES ('None');
 
 CREATE TABLE delta.Botanists (
     botanist_id INT IDENTITY (1, 1) PRIMARY KEY,


### PR DESCRIPTION
seeded a value of "None" into scientific_names table on schema, to allow for missing scientific name values from API, referring to ticket #33 .